### PR TITLE
hotfix/TOPS-800: Renaming gsoft-inc organization to workleap in github.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
   linearb:
     needs: [main]
-    uses: gsoft-inc/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
+    uses: workleap/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
     with:
       environment: development
     secrets: inherit

--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-workflow-jira:
-    uses: gsoft-inc/wl-reusable-workflows/.github/workflows/reusable-jira-workflow.yml@main
+    uses: workleap/wl-reusable-workflows/.github/workflows/reusable-jira-workflow.yml@main
     with:
       branch_name: ${{ github.head_ref }}
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
 
   linearb:
     needs: [main]
-    uses: gsoft-inc/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
+    uses: workleap/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
     with:
       environment: 'release'
     secrets: inherit

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -12,4 +12,4 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    uses: gsoft-inc/wl-reusable-workflows/.github/workflows/reusable-semgrep-workflow.yml@main
+    uses: workleap/wl-reusable-workflows/.github/workflows/reusable-semgrep-workflow.yml@main

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Workleap.DotNet.CodingStandards
 
 [![nuget](https://img.shields.io/nuget/v/Workleap.DotNet.CodingStandards.svg?logo=nuget)](https://www.nuget.org/packages/Workleap.DotNet.CodingStandards/)
-[![build](https://img.shields.io/github/actions/workflow/status/gsoft-inc/wl-dotnet-codingstandards/publish.yml?logo=github&branch=main)](https://github.com/gsoft-inc/wl-dotnet-codingstandards/actions/workflows/publish.yml)
+[![build](https://img.shields.io/github/actions/workflow/status/gsoft-inc/wl-dotnet-codingstandards/publish.yml?logo=github&branch=main)](https://github.com/workleap/wl-dotnet-codingstandards/actions/workflows/publish.yml)
 
 This package provides a set of **programming standards for .NET projects**, including rules for **style**, **quality**, **security**, and **performance**. It relies on [built-in .NET analyzers](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview) that are shipped with the .NET SDK.
 
@@ -131,4 +131,4 @@ To publish a new public (non-preview) version, simply create a new release on Gi
 
 ## License
 
-Copyright © 2024, Workleap. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/gsoft-inc/gsoft-license/blob/master/LICENSE.
+Copyright © 2024, Workleap. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/workleap/gsoft-license/blob/master/LICENSE.

--- a/Workleap.DotNet.CodingStandards.nuspec
+++ b/Workleap.DotNet.CodingStandards.nuspec
@@ -8,7 +8,7 @@
     <developmentDependency>true</developmentDependency>
     <license type="expression">Apache-2.0</license>
     <readme>README.md</readme>
-    <projectUrl>https://github.com/gsoft-inc/wl-dotnet-codingstandards</projectUrl>
+    <projectUrl>https://github.com/workleap/wl-dotnet-codingstandards</projectUrl>
     <description>Workleap recommended coding standards for .NET.</description>
     <copyright>Copyright © Workleap</copyright>
     <repository type="git" url="$RepositoryUrl$" commit="$RepositoryCommit$" branch="$RepositoryBranch$" />


### PR DESCRIPTION
TOPS-800: Replacing gsoft-inc/wl-reusable-workflows by workleap/wl-reusable-workflows

--
Not sure why this PR has been created? Reach TechOps in our public slack channel: #techops-and-friends
Some context on the why of this PR can be found here: https://workleap.slack.com/archives/C02E9KPRQ7P/p1737385211295479 