### PR TITLE
[IDP-3177] Manual dependency updates and automatic editorconfig updates

### DIFF
--- a/src/files/analyzers/Analyzer.Microsoft.CodeAnalysis.CSharp.CodeStyle.editorconfig
+++ b/src/files/analyzers/Analyzer.Microsoft.CodeAnalysis.CSharp.CodeStyle.editorconfig
@@ -207,12 +207,12 @@ dotnet_diagnostic.IDE0048.severity = silent
 
 # IDE0051: Remove unused private members
 # Help link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0051
-# Enabled: True, Severity: suggestion
+# Enabled: True, Severity: silent
 dotnet_diagnostic.IDE0051.severity = suggestion
 
 # IDE0052: Remove unread private members
 # Help link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0052
-# Enabled: True, Severity: suggestion
+# Enabled: True, Severity: silent
 dotnet_diagnostic.IDE0052.severity = suggestion
 
 # IDE0053: Use block body for lambda expression
@@ -380,6 +380,11 @@ dotnet_diagnostic.IDE0110.severity = warning
 # Enabled: True, Severity: silent
 dotnet_diagnostic.IDE0120.severity = silent
 
+# IDE0121: Simplify LINQ expression
+# Help link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0121
+# Enabled: True, Severity: silent
+dotnet_diagnostic.IDE0121.severity = silent
+
 # IDE0130: Namespace does not match folder structure
 # Help link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0130
 # Enabled: True, Severity: silent
@@ -505,6 +510,11 @@ dotnet_diagnostic.IDE0304.severity = suggestion
 # Enabled: True, Severity: silent
 dotnet_diagnostic.IDE0305.severity = suggestion
 
+# IDE0306: Simplify collection initialization
+# Help link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0306
+# Enabled: True, Severity: silent
+dotnet_diagnostic.IDE0306.severity = silent
+
 # IDE0320: Make anonymous function static
 # Help link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0320
 # Enabled: True, Severity: silent
@@ -514,6 +524,11 @@ dotnet_diagnostic.IDE0320.severity = silent
 # Help link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0330
 # Enabled: True, Severity: silent
 dotnet_diagnostic.IDE0330.severity = suggestion
+
+# IDE0340: Use unbound generic type
+# Help link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0340
+# Enabled: True, Severity: silent
+dotnet_diagnostic.IDE0340.severity = silent
 
 # IDE1005: Delegate invocation can be simplified.
 # Help link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1005

--- a/tests/Workleap.DotNet.CodingStandards.Tests/Workleap.DotNet.CodingStandards.Tests.csproj
+++ b/tests/Workleap.DotNet.CodingStandards.Tests/Workleap.DotNet.CodingStandards.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CliWrap" Version="3.8.0" />
+    <PackageReference Include="CliWrap" Version="3.8.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">

--- a/tools/ConfigurationFilesGenerator/ConfigurationFilesGenerator.csproj
+++ b/tools/ConfigurationFilesGenerator/ConfigurationFilesGenerator.csproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Framework.FullPath" Version="1.0.15" />
+    <PackageReference Include="Meziantou.Framework.FullPath" Version="1.0.16" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.12.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.12.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.12.0" />
-    <PackageReference Include="NuGet.Protocol" Version="6.13.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.13.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.13.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.13.0" />
+    <PackageReference Include="NuGet.Protocol" Version="6.13.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description of changes

1. Manually bumped NuGet packages. `Build.ps1` would fail for several Renovate PRs due to unmet dependencies. Given that I knew .editorconfig files would change and require approval, I decided to regroup all 4 PRs in a single one.

2. Automatically update the .editorconfig file. No severity change required in my opinion.

## Breaking changes
N/A

## Additional checks
New release required after merge.

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
