### PR TITLE
Embed pdb instead of using snupkg

### DIFF
--- a/src/build/Workleap.DotNet.CodingStandards.props
+++ b/src/build/Workleap.DotNet.CodingStandards.props
@@ -6,8 +6,9 @@
     <EnableNETAnalyzers Condition="'$(EnableNETAnalyzers)' == ''">true</EnableNETAnalyzers>
     <AnalysisLevel Condition="'$(AnalysisLevel)' == ''">latest-all</AnalysisLevel>
     <EnforceCodeStyleInBuild Condition="'$(EnforceCodeStyleInBuild)' == ''">true</EnforceCodeStyleInBuild>
-    <IncludeSymbols Condition="'$(IncludeSymbols)' == ''">true</IncludeSymbols>
-    <SymbolPackageFormat Condition="'$(SymbolPackageFormat)' == ''">snupkg</SymbolPackageFormat>
+
+    <EmbedUntrackedSources Condition="'$(EmbedUntrackedSources)' == ''">true</EmbedUntrackedSources>
+    <DebugType Condition="'$(DebugType)' == ''">embedded</DebugType>
 
     <!-- Prevent warning when the .NET SDK version and the Microsoft.CodeAnalysis.NetAnalyzers version mismatch -->
     <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>


### PR DESCRIPTION
## Description of changes

- embedded pdf are easier to use as they are always accessible.
- Drawbacks:
  - Larger dll (a few kB)
  - At runtime, pdb may slow down stack trace generation (should be marginal)