### PR TITLE
Bump M.CA.BannedApiAnalyzers to 4.14.0 to support banning namespaces

### DIFF
--- a/Workleap.DotNet.CodingStandards.nuspec
+++ b/Workleap.DotNet.CodingStandards.nuspec
@@ -14,7 +14,7 @@
     <repository type="git" url="$RepositoryUrl$" commit="$RepositoryCommit$" branch="$RepositoryBranch$" />
     <dependencies>
       <dependency id="Meziantou.Analyzer" version="2.0.201" />
-      <dependency id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="3.3.4" />
+      <dependency id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="4.14.0" />
       <dependency id="Microsoft.CodeAnalysis.NetAnalyzers" version="9.0.0" />
       <dependency id="StyleCop.Analyzers" version="1.2.0-beta.556" />
     </dependencies>

--- a/src/files/analyzers/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig
+++ b/src/files/analyzers/Analyzer.Microsoft.CodeAnalysis.BannedApiAnalyzers.editorconfig
@@ -3,12 +3,12 @@ is_global = true
 global_level = 0
 
 # RS0030: Do not use banned APIs
-# Help link: https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md
+# Help link: https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md
 # Enabled: True, Severity: warning
 dotnet_diagnostic.RS0030.severity = warning
 
 # RS0031: The list of banned symbols contains a duplicate
-# Help link: https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md
+# Help link: https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md
 # Enabled: True, Severity: warning
 dotnet_diagnostic.RS0031.severity = warning
 


### PR DESCRIPTION
## Description of changes

A team wants to ban a whole namespace, but the current version of M.CA.BannedApiAnalyzers doesn't support it - updating the dependency will help.

Example of BannedSymbols.txt that will work with this change (doesn't do anything now):

```
N:System.Threading
N:System.Threading.Tasks
N:Workleap.Extensions.Mongo
```

![image](https://github.com/user-attachments/assets/770446d0-6833-4804-b563-e8f3617e95e3)

## Breaking changes

N/A

## Additional checks

Analyzer docs: https://github.com/dotnet/roslyn-analyzers/blob/9.0.0/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md
